### PR TITLE
Remove extraneous parens in usage example (gofmt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ func main() {
     ExecutionPeriod: 10 * time.Second, // the check will be executed every 10 sec
   })
   
-  if (err != nil) {
+  if err != nil {
     fmt.Println("Failed to register check: ", err)
     return // or whatever
   }


### PR DESCRIPTION
Remove extraneous parentheses around `(err != nil)` to make the example code more idiomatic (as `gofmt` normally removes such parentheses). Otherwise, the code looks strange to those familiar with the `gofmt` style, which is to say most Go developers.