### PR TITLE
fixed #20 - POST body for HTTP checks wasn't preserved

### DIFF
--- a/checks/http.go
+++ b/checks/http.go
@@ -1,7 +1,6 @@
 package checks
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -25,7 +24,7 @@ type HTTPCheckConfig struct {
 	// Method is optional and defaults to `GET` if undefined.
 	Method string
 	// Body is an optional request body to be posted to the target URL.
-	Body io.Reader
+	Body BodyProvider
 	// ExpectedStatus is the expected response status code, defaults to `200`.
 	ExpectedStatus int
 	// ExpectedBody is optional; if defined, operates as a basic "body should contain <string>".
@@ -43,9 +42,11 @@ type RequestOption func(r *http.Request)
 
 type httpCheck struct {
 	config         *HTTPCheckConfig
-	payload        []byte
 	successDetails string
 }
+
+// BodyProvider allows the users to provide a body to the HTTP checks. For example for posting a payload as a check.
+type BodyProvider func() io.Reader
 
 // NewHTTPCheck creates a new http check defined by the given config
 func NewHTTPCheck(config HTTPCheckConfig) (check Check, err error) {
@@ -66,12 +67,8 @@ func NewHTTPCheck(config HTTPCheckConfig) (check Check, err error) {
 	if config.Method == "" {
 		config.Method = http.MethodGet
 	}
-	var payload []byte
-	if config.Body != nil {
-		payload, err = ioutil.ReadAll(config.Body)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to read body")
-		}
+	if config.Body == nil {
+		config.Body = func() io.Reader { return http.NoBody }
 	}
 	if config.Timeout == 0 {
 		config.Timeout = time.Second
@@ -83,7 +80,6 @@ func NewHTTPCheck(config HTTPCheckConfig) (check Check, err error) {
 
 	check = &httpCheck{
 		config:         &config,
-		payload:        payload,
 		successDetails: fmt.Sprintf("URL [%s] is accessible", config.URL),
 	}
 	return check, nil
@@ -99,7 +95,7 @@ func (check *httpCheck) Execute() (details interface{}, err error) {
 	if err != nil {
 		return details, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != check.config.ExpectedStatus {
 		return details, errors.Errorf("unexpected status code: '%v' expected: '%v'",
@@ -124,7 +120,7 @@ func (check *httpCheck) Execute() (details interface{}, err error) {
 // fetchURL executes the HTTP request to the target URL, and returns a `http.Response`, error.
 // It is the callers responsibility to close the response body
 func (check *httpCheck) fetchURL() (*http.Response, error) {
-	req, err := http.NewRequest(check.config.Method, check.config.URL, bytes.NewBuffer(check.payload))
+	req, err := http.NewRequest(check.config.Method, check.config.URL, check.config.Body())
 	if err != nil {
 		return nil, errors.Errorf("unable to create check HTTP request: %v", err)
 	}

--- a/checks/http_test.go
+++ b/checks/http_test.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -155,7 +156,7 @@ func testHTTPCheckSuccessWithPostBodyPayload(url string, client *http.Client) fu
 			URL:          url,
 			Client:       client,
 			ExpectedBody: postPayload,
-			Body:         strings.NewReader(postPayload),
+			Body:         func() io.Reader { return strings.NewReader(postPayload) },
 			Method:       http.MethodPost,
 		})
 		assert.Nil(t, err)

--- a/checks/http_test.go
+++ b/checks/http_test.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -89,7 +90,14 @@ func TestNewHttpCheck(t *testing.T) {
 		}
 
 		rw.WriteHeader(200)
-		_, err := rw.Write([]byte(expectedContent))
+
+		reqBody, _ := ioutil.ReadAll(req.Body)
+		responsePayload := expectedContent
+		if len(reqBody) != 0 {
+			responsePayload = string(reqBody)
+		}
+
+		_, err := rw.Write([]byte(responsePayload))
 		if err != nil {
 			t.Fatal("Failed to write response: ", err)
 		}
@@ -98,8 +106,9 @@ func TestNewHttpCheck(t *testing.T) {
 	defer server.Close()
 
 	t.Run("HttpCheck success call", testHTTPCheckSuccess(server.URL, server.Client()))
-	t.Run("HttpCheck success call with body check", testHTTPCheckSuccessWithExpectedBody(server.URL, server.Client()))
-	t.Run("HttpCheck success call with failing body check", testHTTPCheckFailWithUnexpectedBody(server.URL, server.Client()))
+	t.Run("HttpCheck success call with expected body check", testHTTPCheckSuccessWithExpectedBody(server.URL, server.Client()))
+	t.Run("HttpCheck success call with POST body payload", testHTTPCheckSuccessWithPostBodyPayload(server.URL, server.Client()))
+	t.Run("HttpCheck success call with failing expected body check", testHTTPCheckFailWithUnexpectedBody(server.URL, server.Client()))
 	t.Run("HttpCheck success call with options", testHTTPCheckSuccessWithOptions(server.URL, server.Client(), &receivedDetails))
 	t.Run("HttpCheck fail on status code", testHTTPCheckFailStatusCode(server.URL, server.Client()))
 	t.Run("HttpCheck fail on URL", testHTTPCheckFailURL(server.URL, server.Client()))
@@ -134,6 +143,28 @@ func testHTTPCheckSuccessWithExpectedBody(url string, client *http.Client) func(
 		details, err := check.Execute()
 		assert.Nil(t, err, "check should pass")
 		assert.Equal(t, fmt.Sprintf("URL [%s] is accessible", url), details, "check should pass")
+	}
+}
+
+func testHTTPCheckSuccessWithPostBodyPayload(url string, client *http.Client) func(t *testing.T) {
+	return func(t *testing.T) {
+		const postPayload = "body-payload"
+
+		check, err := NewHTTPCheck(HTTPCheckConfig{
+			CheckName:    "url.check",
+			URL:          url,
+			Client:       client,
+			ExpectedBody: postPayload,
+			Body:         strings.NewReader(postPayload),
+			Method:       http.MethodPost,
+		})
+		assert.Nil(t, err)
+
+		for i := 0; i < 5; i++ {
+			details, err := check.Execute()
+			assert.Nil(t, err, "check should pass")
+			assert.Equal(t, fmt.Sprintf("URL [%s] is accessible", url), details, "check should pass")
+		}
 	}
 }
 


### PR DESCRIPTION
POST body for HTTP checks wasn't preserved and only the first check posted the requested payload.

Now copying the Body Reader content upon check creation.
I guess we could change the API to use some PayloadProvider instead of a reader, but it's a breaking change...

This PR fixes #20 