### PR TITLE
set default execution period to avoid panic

### DIFF
--- a/health.go
+++ b/health.go
@@ -59,11 +59,18 @@ type health struct {
 }
 
 func (h *health) RegisterCheck(check Check, opts ...CheckOption) error {
-	if check == nil || check.Name() == "" {
-		return errors.Errorf("misconfigured check %v", check)
+	if check == nil {
+		return errors.New("check must not be nil")
+	}
+	if check.Name() == "" {
+		return errors.New("check name must not be empty")
 	}
 
 	cfg := h.initCheckConfig(opts)
+
+	if cfg.executionPeriod <= 0 {
+		return errors.New("execution period must be greater than 0")
+	}
 
 	// checks are initially failing by default, but we allow overrides...
 	var initialErr error

--- a/health_test.go
+++ b/health_test.go
@@ -43,8 +43,7 @@ func TestHealthWithBogusCheck(t *testing.T) {
 	err := h.RegisterCheck(nil)
 	defer h.DeregisterAll()
 
-	assert.Error(t, err, "register bogus check should fail")
-	assert.Contains(t, err.Error(), "misconfigured check", "fail message")
+	assert.EqualError(t, err, "check must not be nil")
 	assert.True(t, h.IsHealthy(), "health after bogus register")
 
 	results, healthy := h.Results()
@@ -54,6 +53,7 @@ func TestHealthWithBogusCheck(t *testing.T) {
 
 func TestRegisterCheckValidations(t *testing.T) {
 	h := New()
+	defer h.DeregisterAll()
 
 	// should return an error for nil check
 	assert.EqualError(t, h.RegisterCheck(nil), "check must not be nil")
@@ -63,6 +63,8 @@ func TestRegisterCheckValidations(t *testing.T) {
 	assert.EqualError(t, h.RegisterCheck(&checks.CustomCheck{CheckName: "non-empty"}), "execution period must be greater than 0")
 
 	hWithExecPeriod := New(ExecutionPeriod(1 * time.Minute))
+	defer hWithExecPeriod.DeregisterAll()
+
 	assert.NoError(t, hWithExecPeriod.RegisterCheck(&checks.CustomCheck{CheckName: "non-empty"}))
 
 }

--- a/health_test.go
+++ b/health_test.go
@@ -52,6 +52,21 @@ func TestHealthWithBogusCheck(t *testing.T) {
 	assert.Empty(t, results, "results after bogus register")
 }
 
+func TestRegisterCheckValidations(t *testing.T) {
+	h := New()
+
+	// should return an error for nil check
+	assert.EqualError(t, h.RegisterCheck(nil), "check must not be nil")
+	// should return an error for missing check name
+	assert.EqualError(t, h.RegisterCheck(&checks.CustomCheck{}), "check name must not be empty")
+	// Should return an error for missing execution period
+	assert.EqualError(t, h.RegisterCheck(&checks.CustomCheck{CheckName: "non-empty"}), "execution period must be greater than 0")
+
+	hWithExecPeriod := New(ExecutionPeriod(1 * time.Minute))
+	assert.NoError(t, hWithExecPeriod.RegisterCheck(&checks.CustomCheck{CheckName: "non-empty"}))
+
+}
+
 func TestRegisterDeregister(t *testing.T) {
 	leaktest.Check(t)
 

--- a/health_test.go
+++ b/health_test.go
@@ -65,6 +65,7 @@ func TestRegisterCheckValidations(t *testing.T) {
 	hWithExecPeriod := New(ExecutionPeriod(1 * time.Minute))
 	defer hWithExecPeriod.DeregisterAll()
 
+	// should inherit the execution period from the health instance
 	assert.NoError(t, hWithExecPeriod.RegisterCheck(&checks.CustomCheck{CheckName: "non-empty"}))
 
 }

--- a/options.go
+++ b/options.go
@@ -37,7 +37,11 @@ func WithHealthListeners(listener ...HealthListener) HealthOption {
 // WithDefaults sets all the Health object settings. It's not required to use this as no options is always default
 // This is a simple placeholder for any future defaults
 func WithDefaults() HealthOption {
-	return healthOptionFunc(func(h *health) {})
+	return healthOptionFunc(func(h *health) {
+		if h.defaultExecutionPeriod == 0 {
+			h.defaultExecutionPeriod = 1 * time.Minute
+		}
+	})
 }
 
 // CheckOption configures a health check using the functional options paradigm

--- a/options.go
+++ b/options.go
@@ -38,7 +38,7 @@ func WithHealthListeners(listener ...HealthListener) HealthOption {
 // This is a simple placeholder for any future defaults
 func WithDefaults() HealthOption {
 	return healthOptionFunc(func(h *health) {
-		if h.defaultExecutionPeriod == 0 {
+		if h.defaultExecutionPeriod <= 0 {
 			h.defaultExecutionPeriod = 1 * time.Minute
 		}
 	})

--- a/options.go
+++ b/options.go
@@ -37,11 +37,7 @@ func WithHealthListeners(listener ...HealthListener) HealthOption {
 // WithDefaults sets all the Health object settings. It's not required to use this as no options is always default
 // This is a simple placeholder for any future defaults
 func WithDefaults() HealthOption {
-	return healthOptionFunc(func(h *health) {
-		if h.defaultExecutionPeriod <= 0 {
-			h.defaultExecutionPeriod = 1 * time.Minute
-		}
-	})
+	return healthOptionFunc(func(h *health) {})
 }
 
 // CheckOption configures a health check using the functional options paradigm


### PR DESCRIPTION
If `ExecutionPeriod` option is unset on either the `Health` instance or the individual check, the code will panic when attempting to create a new ticker in `scheduleCheck`, since the execution period's default value is 0:

```
func NewTicker(d Duration) *Ticker {
	if d <= 0 {
		panic(errors.New("non-positive interval for NewTicker"))
	}
	....
```	