### PR TITLE
Add sentinel error to indicate a check has not run yet

### DIFF
--- a/health.go
+++ b/health.go
@@ -2,7 +2,6 @@ package gosundheit
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -75,10 +74,10 @@ func (h *health) RegisterCheck(check Check, opts ...CheckOption) error {
 	// checks are initially failing by default, but we allow overrides...
 	var initialErr error
 	if !cfg.initiallyPassing {
-		initialErr = fmt.Errorf(initialResultMsg)
+		initialErr = ErrNotRunYet
 	}
 
-	result := h.updateResult(check.Name(), initialResultMsg, 0, initialErr, time.Now())
+	result := h.updateResult(check.Name(), ErrNotRunYet.Error(), 0, initialErr, time.Now())
 	h.checksListener.OnCheckRegistered(check.Name(), result)
 	h.scheduleCheck(h.createCheckTask(check, cfg.executionTimeout), cfg.initialDelay, cfg.executionPeriod)
 	return nil

--- a/health_test.go
+++ b/health_test.go
@@ -96,7 +96,9 @@ func TestRegisterDeregister(t *testing.T) {
 	assert.False(t, failingCheck.IsHealthy(), "check initially fails until first execution by default")
 	assert.True(t, initiallyPassingCheck.IsHealthy(), "check should initially pass")
 	assert.Contains(t, passingCheck.String(), "didn't run yet", "initial details")
+	assert.EqualError(t, passingCheck.Error, gosundheit.ErrNotRunYet.Error(), "initial details")
 	assert.Contains(t, failingCheck.String(), "didn't run yet", "initial details")
+	assert.EqualError(t, failingCheck.Error, gosundheit.ErrNotRunYet.Error(), "initial details")
 	assert.Contains(t, initiallyPassingCheck.String(), "didn't run yet", "initial details")
 
 	// await first execution

--- a/types.go
+++ b/types.go
@@ -9,9 +9,12 @@ import (
 
 const (
 	maxExpectedChecks = 16
-	initialResultMsg  = "didn't run yet"
 	// ValAllChecks is the value used for the check tags when tagging all tests
 	ValAllChecks = "all_checks"
+)
+
+var (
+	ErrNotRunYet = errors.New("didn't run yet")
 )
 
 // Result represents the output of a health check execution.


### PR DESCRIPTION
Add a sentinel error to indicate that a health check did not run yet, to allow listeners to distinguish between an actual failure and a check that did not run yet.