### PR TITLE
deprecate github.com/pkg/errors

### DIFF
--- a/health_test.go
+++ b/health_test.go
@@ -96,9 +96,9 @@ func TestRegisterDeregister(t *testing.T) {
 	assert.False(t, failingCheck.IsHealthy(), "check initially fails until first execution by default")
 	assert.True(t, initiallyPassingCheck.IsHealthy(), "check should initially pass")
 	assert.Contains(t, passingCheck.String(), "didn't run yet", "initial details")
-	assert.EqualError(t, passingCheck.Error, gosundheit.ErrNotRunYet.Error(), "initial details")
+	assert.True(t, errors.Is(passingCheck.Error, gosundheit.ErrNotRunYet))
 	assert.Contains(t, failingCheck.String(), "didn't run yet", "initial details")
-	assert.EqualError(t, failingCheck.Error, gosundheit.ErrNotRunYet.Error(), "initial details")
+	assert.True(t, errors.Is(failingCheck.Error, gosundheit.ErrNotRunYet))
 	assert.Contains(t, initiallyPassingCheck.String(), "didn't run yet", "initial details")
 
 	// await first execution

--- a/types.go
+++ b/types.go
@@ -1,20 +1,17 @@
 package gosundheit
 
 import (
+	"errors"
 	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 const (
 	maxExpectedChecks = 16
-	// ValAllChecks is the value used for the check tags when tagging all tests
-	ValAllChecks = "all_checks"
 )
 
 var (
-	ErrNotRunYet = errors.New("didn't run yet")
+	ErrNotRunYet = newMarshalableError(errors.New("didn't run yet"))
 )
 
 // Result represents the output of a health check execution.
@@ -53,18 +50,17 @@ func newMarshalableError(err error) error {
 		return nil
 	}
 
-	mr := &marshalableError{
+	mr := marshalableError{
 		Message: err.Error(),
 	}
-
-	cause := errors.Cause(err)
-	if cause != err {
+	cause := errors.Unwrap(err)
+	if !errors.Is(cause, err) {
 		mr.Cause = newMarshalableError(cause)
 	}
 
 	return mr
 }
 
-func (e *marshalableError) Error() string {
+func (e marshalableError) Error() string {
 	return e.Message
 }


### PR DESCRIPTION
* Deprecate the usage of github.com/pkg/errors in favor of the std errors package
* Use newMarshalableError as the type of the ErrNotRunYet sentinel error